### PR TITLE
Fix the #include issues before clang-format is run

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,134 @@
+Language:        Cpp
+# BasedOnStyle:  Microsoft
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: None
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+ColumnLimit:     120
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '<[[:alnum:].]+>'
+    Priority:        4
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never

--- a/include/anim_sequence.h
+++ b/include/anim_sequence.h
@@ -24,6 +24,8 @@
 #include "animation.h"
 #include "tiledmap.h"
 
+#include <cstdint>
+
 class KAnimSequence
 {
 public:

--- a/include/animation.h
+++ b/include/animation.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 using std::vector;
 

--- a/include/bounds.h
+++ b/include/bounds.h
@@ -22,9 +22,10 @@
 #pragma once
 
 #include <allegro.h>
+#include <cstdint>
 #include <memory>
-using std::shared_ptr;
 #include <vector>
+using std::shared_ptr;
 using std::vector;
 
 struct PACKFILE;

--- a/include/combat.h
+++ b/include/combat.h
@@ -31,7 +31,7 @@
  * \date ????????
  */
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "enums.h"

--- a/include/console.h
+++ b/include/console.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <allegro.h>
 
 void display_console(uint32_t, uint32_t);

--- a/include/disk.h
+++ b/include/disk.h
@@ -29,11 +29,11 @@
 #include "structs.h"
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <iterator>
 #include <map>
-#include <stdint.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 #include <string>
 #include <tinyxml2.h>
 #include <vector>

--- a/include/draw.h
+++ b/include/draw.h
@@ -23,8 +23,8 @@
 
 #include "enums.h"
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 #include <string>
 using std::string;
 

--- a/include/effects.h
+++ b/include/effects.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 class KEffects
 {
 public:

--- a/include/enemyc.h
+++ b/include/enemyc.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 class KFighter;

--- a/include/entity.h
+++ b/include/entity.h
@@ -29,6 +29,8 @@
  * \date ??????
  */
 
+#include <cstdint>
+
 typedef uint32_t t_entity;
 
 void process_entities(void);

--- a/include/eqpmenu.h
+++ b/include/eqpmenu.h
@@ -21,4 +21,6 @@
 
 #pragma once
 
+#include <cstdint>
+
 void equip_menu(uint32_t);

--- a/include/eskill.h
+++ b/include/eskill.h
@@ -25,4 +25,6 @@
  * \brief Enemy Skills header file
  */
 
+#include <cstdint>
+
 void combat_skill(size_t);

--- a/include/fighter.h
+++ b/include/fighter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <allegro.h>
+#include <cstdint>
 #include "enums.h"
 #include "structs.h"
 class Raster;

--- a/include/gettext.h
+++ b/include/gettext.h
@@ -44,7 +44,7 @@
    and also including <libintl.h> would fail on SunOS 4, whereas <locale.h>
    is OK.  */
 #if defined(__sun)
-#include <locale.h>
+#include <clocale>
 #endif
 
 /* Many header files from the libstdc++ coming with g++ 3.3 or newer include
@@ -183,7 +183,7 @@ inline
    can be arbitrary expressions.  But for string literals these macros are
    less efficient than those above.  */
 
-#include <string.h>
+#include <cstring>
 
 #if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) &&         \
      !defined __cplusplus)
@@ -193,7 +193,7 @@ inline
 #endif
 
 #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
-#include <stdlib.h>
+#include <cstdlib>
 #endif
 
 #define pgettext_expr(Msgctxt, Msgid)                                          \

--- a/include/gfx.h
+++ b/include/gfx.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 struct BITMAP;
 

--- a/include/heroc.h
+++ b/include/heroc.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <stdlib.h>
+#include <cstdlib>
 /*! \file
  * \brief Hero combat header file
  */

--- a/include/heroc.h
+++ b/include/heroc.h
@@ -21,7 +21,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
+
 /*! \file
  * \brief Hero combat header file
  */

--- a/include/hskill.h
+++ b/include/hskill.h
@@ -21,5 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
+
 int hero_skillcheck(size_t);
 int skill_use(size_t);

--- a/include/itemmenu.h
+++ b/include/itemmenu.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #define MAX_ITEMS 9
 
 enum eItemEffectResult {

--- a/include/kq.h
+++ b/include/kq.h
@@ -48,7 +48,7 @@
 #endif /* MSVC */
 #endif /* GNUC */
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 using std::string;
 

--- a/include/magic.h
+++ b/include/magic.h
@@ -31,6 +31,8 @@
 #include "kq.h"
 #include "structs.h"
 
+#include <cstdint>
+
 enum EMagic
 {
 	M_CURE1 = 1,

--- a/include/maps.h
+++ b/include/maps.h
@@ -28,9 +28,10 @@
  */
 
 #include <allegro.h>
+#include <cstdint>
 #include <string>
-using std::string;
 #include <vector>
+using std::string;
 using std::vector;
 
 #include "bounds.h"

--- a/include/markers.h
+++ b/include/markers.h
@@ -21,11 +21,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
-using std::shared_ptr;
 #include <string>
-using std::string;
 #include <vector>
+using std::shared_ptr;
+using std::string;
 using std::vector;
 
 /*! \file

--- a/include/menu.h
+++ b/include/menu.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "kq.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/movement.h
+++ b/include/movement.h
@@ -21,6 +21,6 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 int find_path(size_t, uint32_t, uint32_t, uint32_t, uint32_t, char *, uint32_t);

--- a/include/player.h
+++ b/include/player.h
@@ -4,6 +4,7 @@
 #include "heroc.h"
 #include "res.h"
 
+#include <cstdint>
 #include <string>
 using std::string;
 

--- a/include/res.h
+++ b/include/res.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <allegro.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include "enums.h"
 #include "heroc.h"

--- a/include/selector.h
+++ b/include/selector.h
@@ -24,6 +24,8 @@
 #include "enums.h"
 #include "heroc.h"
 
+#include <cstdint>
+
 int select_player(void);
 ePIDX select_any_player(eTarget, unsigned int, const char *);
 ePIDX select_hero(size_t, eTarget, bool);

--- a/include/shopmenu.h
+++ b/include/shopmenu.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #define NUMSHOPS 50
 #define SHOPITEMS 12
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -34,6 +34,8 @@
 #include "res.h"
 class Raster;
 
+#include <cstdint>
+
 /*! \brief Entity
  *
  * Contains info on an entity's appearance, position and behaviour */

--- a/include/tiledmap.h
+++ b/include/tiledmap.h
@@ -21,12 +21,14 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
-using std::unique_ptr;
 #include <string>
-using std::string;
 #include <tinyxml2.h>
 #include <vector>
+
+using std::unique_ptr;
+using std::string;
 using std::vector;
 using namespace tinyxml2;
 

--- a/include/tmx_tileset.h
+++ b/include/tmx_tileset.h
@@ -1,14 +1,21 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "gfx.h"
+#include "tmx_animation.h"
+
 class KTmxTileset {
 public:
   KTmxTileset() : imagedata(nullptr) {}
 
   uint32_t firstgid;
-  string name;
-  string sourceimage;
+  std::string name;
+  std::string sourceimage;
   Raster *imagedata;
-  vector<KTmxAnimation> animations;
+  std::vector<KTmxAnimation> animations;
   int width;
   int height;
 };

--- a/src/bounds.cpp
+++ b/src/bounds.cpp
@@ -25,12 +25,12 @@
 * \date 20060720
 */
 
-#include <assert.h>
-#include <ctype.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "bounds.h"
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -28,8 +28,8 @@
  */
 
 #include <memory>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include<iostream>
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -27,7 +27,7 @@
 #include "kq.h"
 #include "music.h"
 #include "structs.h"
-#include <stddef.h>
+#include <cstddef>
 
 /*! \file
 * \brief Lua console for debugging

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -28,10 +28,10 @@
  * Also some colour manipulation.
  */
 
-#include <assert.h>
-#include <ctype.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
 
 #include "bounds.h"
 #include "combat.h"

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -27,8 +27,8 @@
  */
 
 #include <memory>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "draw.h"

--- a/src/enemyc.cpp
+++ b/src/enemyc.cpp
@@ -30,8 +30,8 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "disk.h"

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -26,13 +26,13 @@
  * \date ??????
  */
 
-#include <assert.h>
-#include <ctype.h>
-#include <math.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "combat.h"
 #include "entity.h"

--- a/src/eqpmenu.cpp
+++ b/src/eqpmenu.cpp
@@ -28,8 +28,8 @@
  * including dropping and optimizing the items carried.
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "draw.h"
 #include "eqpmenu.h"

--- a/src/eskill.cpp
+++ b/src/eskill.cpp
@@ -19,8 +19,8 @@
        675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "draw.h"

--- a/src/fade.cpp
+++ b/src/fade.cpp
@@ -27,7 +27,7 @@
  */
 
 #include "kq.h"
-#include <string.h>
+#include <cstring>
 
 #include "draw.h"
 #include "fade.h"

--- a/src/heroc.cpp
+++ b/src/heroc.cpp
@@ -53,8 +53,8 @@
 #include "skills.h"
 #include "timing.h"
 #include <memory>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 /* External variables */
 int can_use_item = 1;

--- a/src/hskill.cpp
+++ b/src/hskill.cpp
@@ -27,8 +27,8 @@
  */
 
 #include <memory>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "constants.h"

--- a/src/itemmenu.cpp
+++ b/src/itemmenu.cpp
@@ -26,8 +26,8 @@
  * \date ????????
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "draw.h"

--- a/src/kq.cpp
+++ b/src/kq.cpp
@@ -39,10 +39,10 @@
  * fixes
  */
 
-#include <assert.h>
-#include <locale.h>
+#include <cassert>
+#include <clocale>
 #include <memory>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <time.h>
 #include <vector>

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -19,8 +19,8 @@
        675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "draw.h"

--- a/src/masmenu.cpp
+++ b/src/masmenu.cpp
@@ -19,8 +19,8 @@
        675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "draw.h"

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -19,7 +19,7 @@
        675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "constants.h"
 #include "draw.h"

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -31,8 +31,8 @@
 
 #include "movement.h"
 #include "kq.h"
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 static int compose_path(AL_CONST int *, uint32_t, uint32_t, char *, size_t);
 static void copy_map(int *);

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -26,8 +26,8 @@
  * Interfaces to DUMB
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <string>
 
 #include "kq.h"

--- a/src/music_dumb.cpp
+++ b/src/music_dumb.cpp
@@ -27,7 +27,7 @@
  */
 
 #include <aldumb.h>
-#include <string.h>
+#include <cstring>
 
 #include "kq.h"
 #include "music.h"

--- a/src/selector.cpp
+++ b/src/selector.cpp
@@ -25,8 +25,8 @@
  * \author Josh Bolduc
  * \date ????????
  */
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "constants.h"

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -27,8 +27,8 @@
  * \remark Updated  ML Oct-2002
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <string>
 
 #include "combat.h"

--- a/src/sgame.cpp
+++ b/src/sgame.cpp
@@ -32,9 +32,9 @@
  *          mode to be saved/loaded ?
  */
 
-#include <ctype.h>
-#include <stdio.h>
-#include <string.h>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
 
 #include "combat.h"
 #include "constants.h"

--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -26,8 +26,8 @@
  * \date ????????
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "constants.h"
 #include "draw.h"

--- a/src/timing.cpp
+++ b/src/timing.cpp
@@ -28,7 +28,7 @@
  */
 #ifdef _WIN32
 #include <allegro.h>
-#include <stdarg.h>
+#include <cstdarg>
 #include <winalleg.h>
 #endif
 

--- a/src/unix.cpp
+++ b/src/unix.cpp
@@ -31,8 +31,8 @@
 
 #include <allegro.h>
 #include <pwd.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <sys/stat.h>
 
 #include "platform.h"

--- a/src/win.cpp
+++ b/src/win.cpp
@@ -31,7 +31,7 @@
 #include "kq.h"
 #include "platform.h"
 #include <allegro.h>
-#include <stdio.h>
+#include <cstdio>
 // This clashes with a Windows typedef
 #undef PSIZE
 #include <winalleg.h>


### PR DESCRIPTION
This adds `#include <cstdint>` to all files that have any kind of _t: `size_t`, `int32_t`, etc.

I ran `clang-format -i src/*.cpp include/*.h` after this change, and there were no compiler errors, so I believe this is good to go.